### PR TITLE
Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 .build
 cmake-build-*
+build/
+build.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,14 @@ set_target_properties( DemoGafferExtensionModule PROPERTIES PREFIX "" OUTPUT_NAM
 target_compile_definitions( DemoGafferExtensionModule PRIVATE BOOST_SIGNALS_NO_DEPRECATION_WARNING=1 -D_GLIBCXX_USE_CXX11_ABI=0 )
 target_link_libraries( DemoGafferExtensionModule DemoGafferExtension )
 
+string(REPLACE "." "" PYTHON_VERSION_STRIPPED ${PYTHON_VERSION})
+string(REPLACE "3.7" "3.7m" PYTHON_FOLDER ${PYTHON_VERSION})
 if(APPLE)
-  target_include_directories( DemoGafferExtensionModule PRIVATE include ${GAFFER_ROOT}/include ${GAFFER_ROOT}/lib/Python.framework/Versions/2.7/include/python2.7 )
+  target_include_directories( DemoGafferExtensionModule PRIVATE include ${GAFFER_ROOT}/include ${GAFFER_ROOT}/lib/Python.framework/Versions/${PYTHON_VERSION}/include/python${PYTHON_VERSION} )
   target_link_libraries( DemoGafferExtensionModule GafferBindings IECorePython boost_python Python)
 else()
-  target_include_directories( DemoGafferExtensionModule PRIVATE include ${GAFFER_ROOT}/include ${GAFFER_ROOT}/include/python2.7 )
-  target_link_libraries( DemoGafferExtensionModule GafferBindings IECorePython boost_python27 python2.7)
+  target_include_directories( DemoGafferExtensionModule PRIVATE include ${GAFFER_ROOT}/include ${GAFFER_ROOT}/include/python${PYTHON_FOLDER})
+  target_link_libraries( DemoGafferExtensionModule GafferBindings IECorePython boost_python${PYTHON_VERSION_STRIPPED} python${PYTHON_FOLDER})
 endif(APPLE)
 
 install( TARGETS DemoGafferExtensionModule DESTINATION python/DemoGafferExtension )
@@ -49,3 +51,5 @@ install( DIRECTORY startup DESTINATION . FILES_MATCHING PATTERN "*.py" )
 
 # build the extra resources
 install( DIRECTORY resources DESTINATION . FILES_MATCHING PATTERN "*.gfr" PERMISSIONS OWNER_READ GROUP_READ WORLD_READ )
+
+

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ setenv DEMO_INSTALL_PREFIX <your extension install path>
 
 mkdir gafferExtensionDemo/cmake-build-default
 cd gafferExtensionDemo/cmake-build-default
-cmake -DGAFFER_ROOT=$GAFFER_ROOT -DCMAKE_INSTALL_PREFIX=$DEMO_INSTALL_PREFIX ..
+cmake -DGAFFER_ROOT=$GAFFER_ROOT -DCMAKE_INSTALL_PREFIX=$DEMO_INSTALL_PREFIX -DPYTHON_VERSION=2.7 ..
 make install -j <num cores>
 ```
 

--- a/python/DemoGafferExtension/__init__.py
+++ b/python/DemoGafferExtension/__init__.py
@@ -1,6 +1,6 @@
 __import__( "Gaffer" )
 __import__( "GafferScene" )
 
-from _DemoGafferExtension import *
+from ._DemoGafferExtension import *
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "DemoGafferExtension" )

--- a/python/DemoGafferExtensionTest/DemoSceneProcessorTest.py
+++ b/python/DemoGafferExtensionTest/DemoSceneProcessorTest.py
@@ -47,11 +47,11 @@ class DemoSceneProcessorTest( GafferSceneTest.SceneTestCase ) :
 
 		node["b"].setValue( "test" )
 		self.assertEqual( len( s ), 5 )
-		self.failUnless( s[0][0].isSame( node["b"] ) )
-		self.failUnless( s[1][0].isSame( node["out"]["childBounds"] ) )
-		self.failUnless( s[2][0].isSame( node["out"]["bound"] ) )
-		self.failUnless( s[3][0].isSame( node["out"]["object"] ) )
-		self.failUnless( s[4][0].isSame( node["out"] ) )
+		self.assertTrue( s[0][0].isSame( node["b"] ) )
+		self.assertTrue( s[1][0].isSame( node["out"]["childBounds"] ) )
+		self.assertTrue( s[2][0].isSame( node["out"]["bound"] ) )
+		self.assertTrue( s[3][0].isSame( node["out"]["object"] ) )
+		self.assertTrue( s[4][0].isSame( node["out"] ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/DemoGafferExtensionTest/__init__.py
+++ b/python/DemoGafferExtensionTest/__init__.py
@@ -1,4 +1,4 @@
-from DemoSceneProcessorTest import DemoSceneProcessorTest
+from . DemoSceneProcessorTest import DemoSceneProcessorTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/DemoGafferExtensionUI/__init__.py
+++ b/python/DemoGafferExtensionUI/__init__.py
@@ -3,4 +3,4 @@ __import__( "GafferUI" )
 __import__( "GafferScene" )
 __import__( "GafferSceneUI" )
 
-import DemoSceneProcessorUI
+from . import DemoSceneProcessorUI

--- a/python/DemoGafferExtensionUITest/DocumentationTest.py
+++ b/python/DemoGafferExtensionUITest/DocumentationTest.py
@@ -12,7 +12,7 @@ import GafferUITest
 
 class DocumentationTest( GafferUITest.TestCase ) :
 
-    def test( self ) :
+	def test( self ) :
 
 		self.maxDiff = None
 		self.assertNodesAreDocumented(

--- a/python/DemoGafferExtensionUITest/__init__.py
+++ b/python/DemoGafferExtensionUITest/__init__.py
@@ -1,4 +1,4 @@
-from DocumentationTest import DocumentationTest
+from . DocumentationTest import DocumentationTest
 
 if __name__ == "__main__":
 	import unittest


### PR DESCRIPTION
Hey @andrewkaufman,
I've added the PYTHON_VERSION arg. 
Tested to build fine with gaffer-0.59.4.0-linux-python3, cannot verify with python2 because it fails for me with `/usr/bin/ld: cannot find -lboost_python27` but it does fail the same way with your master too though, so I assume it's a problem somewhere on my side..
Cheers 